### PR TITLE
Bug fixes

### DIFF
--- a/bin/openssh-ldap-publickey
+++ b/bin/openssh-ldap-publickey
@@ -212,7 +212,7 @@ unless (
 my $log_level = $conf->{'openssh_ldap_loglevel'};
 my $logfile = $conf->{'openssh_ldap_logfile'} || $fallback_logfile;
 my $timeout = $conf->{'timeout'} || 10;
-my $nss_base_passwd = $conf->{'nss_base_passwd'} || [ "ou=People," .$conf->{'base'} ];
+my $nss_base_passwd = $conf->{'nss_base_passwd'} || [ { nss_base_passwd => "ou=People," .$conf->{'base'}, scope => undef } ];
 my ($mesg, $final_filter);
 $conf = check_credentials($conf, $secret_file);
 

--- a/bin/openssh-ldap-publickey
+++ b/bin/openssh-ldap-publickey
@@ -249,7 +249,7 @@ my $user = $ARGV[0];
 if ( $conf->{'pam_filter'} ){
     $final_filter = "&(".$conf->{'pam_filter'}.")(uid=".$user.")";
 } else {
-    $final_filter = 'cn=*';
+    $final_filter = 'uid='.$user;
 }
 
 foreach my $entity (@$nss_base_passwd) {


### PR DESCRIPTION
This pull request contains two bug fixes:

* If pam_filter was not set in ldap.conf then it used cn=* as the filter (and therefore returning the SSH keys for all users), whereas I believe filtering by uid is the intended behaviour.
* If nss_base_passwd was not set in ldap.conf then the default value is the wrong type and causes the script to fail. (When $nss_base_passwd and $scope were combined and turned into an array in commit 0cb4057595d2 the default value was not updated to reflect the changes.)