### PR TITLE
add also ldif variant of openssh-lpk-openldap.schema

### DIFF
--- a/misc/openssh-lpk-openldap.ldif
+++ b/misc/openssh-lpk-openldap.ldif
@@ -1,0 +1,8 @@
+dn: cn=openssh-lpk-openldap,cn=schema,cn=config
+objectClass: olcSchemaConfig
+olcAttributeTypes: {0}( 1.3.6.1.4.1.24552.500.1.1.1.13 NAME 'sshPublicKey' D
+ ESC 'MANDATORY: OpenSSH Public key' EQUALITY octetStringMatch SYNTAX 1.3.6.
+ 1.4.1.1466.115.121.1.40 )
+olcObjectClasses: {0}( 1.3.6.1.4.1.24552.500.1.1.2.0 NAME 'ldapPublicKey' DE
+ SC 'MANDATORY: OpenSSH LPK objectclass' SUP top AUXILIARY MUST ( sshPublicK
+ ey $ uid ) )


### PR DESCRIPTION
If you want apply schema to current version of ldap you need convert it to ldif format.
For example see [blog post](http://stezz.blogspot.ru/2012/05/how-to-add-new-schema-to-openldap-24.html)  about this.
To simplify things for newbies I suggest add ldif variant of schema, so user can just type:
`sudo ldapadd -Y EXTERNAL -H ldapi:/// -f openssh-lpk-openldap.ldif` and start working.