### PR TITLE
Allow '@' character in username

### DIFF
--- a/bin/openssh-ldap-publickey
+++ b/bin/openssh-ldap-publickey
@@ -282,7 +282,7 @@ if (
 }
 
 # Validate username for any bad characters.
-$ARGV[0] =~ /[^a-zA-Z0-9._-]/ && die("bad characters in username");
+$ARGV[0] =~ /[^a-zA-Z0-9._@-]/ && die("bad characters in username");
 my $user = $ARGV[0];
 
 if ( $conf->{'pam_filter'} ){


### PR DESCRIPTION
Trying to use uid that contains @ caused 'bad characters in username' error This change should fix it.